### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "./bin/brew_finder"

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the BrewFinder project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/'jovial-environment-1521'/brew_finder/blob/master/CODE_OF_CONDUCT.md).
+
+[![Run on Repl.it](https://repl.it/badge/github/LeonorPDX/brew_finder)](https://repl.it/github/LeonorPDX/brew_finder)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).